### PR TITLE
dreprecate distutils and move to setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-import os
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='mulpyplexer',


### PR DESCRIPTION
Hi there! I'm packaging mulpyplexer into an ArchLinux package and find a warning "DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives". I suggest deprecate distutils and move to setuptools to prevent it from not working in Python 3.12 :)